### PR TITLE
Fix a tiny typo in the error message of SublimeKite.py

### DIFF
--- a/sublime-text/SublimeKite.py
+++ b/sublime-text/SublimeKite.py
@@ -54,7 +54,7 @@ class SublimeKite(sublime_plugin.EventListener, threading.Thread):
             sock = self._get_sock()
             sock.sendto(payload, self.SOCK_PATH)
         except Exception as e:
-            print("sock.sento exception: %s" % e)
+            print("sock.sendto exception: %s" % e)
 
     # Implements run from threading.Thread. This is used for reading from
     # the domain socket via _read_loop()


### PR DESCRIPTION
Just a cosmetic change.
This kind of typos will soon be eliminated by Kite's intelligent suggestions :)