### PR TITLE
change publisher name Kite -> kite

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "KiteCode",
   "description": "Kite integration for Visual Studio Code",
   "version": "0.1.0",
-  "publisher": "Kite",
+  "publisher": "kite",
   "engines": {
     "vscode": "^1.0.0"
   },


### PR DESCRIPTION
@tarakju 

vs code plugins [require a publisher](https://code.visualstudio.com/docs/tools/vscecli) but the original `"Kite"` name was unfortunately taken, so i had to change it to `"kite"`