### PR TITLE
Reduce HTTP_TIMEOUT in SublimeKite to < 100ms (to avoid warnings)

### DIFF
--- a/sublime-text/SublimeKite.py
+++ b/sublime-text/SublimeKite.py
@@ -30,7 +30,11 @@ KITED_HOSTPORT = "127.0.0.1:46624"
 EVENT_ENDPOINT = "/clientapi/editor/event"
 ERROR_ENDPOINT = "/clientapi/editor/error"
 COMPLETIONS_ENDPOINT = "/clientapi/editor/completions"
-HTTP_TIMEOUT = 0.5  # timeout for HTTP requests in seconds
+
+# Timeout for HTTP requests (in seconds). Note: Sublime will complain if
+# any EventListener handler takes more than 0.1 seconds. So, we set the timeout
+# to 0.09 seconds.
+HTTP_TIMEOUT = 0.09
 
 VERBOSE = False
 ENABLE_COMPLETIONS = False


### PR DESCRIPTION
@dhung09 cc: @alexflint 

This PR reduces the `HTTP_TIMEOUT` in the sublime plugin to under 100ms. When the HTTP POST request timed out (when Kite died or was exited), our timeout of 500ms would trigger Sublime warnings about the plugin taking too long to respond. It seems the threshold for Sublime is 100ms, so I've set it to 90ms for the time being.