### PR TITLE
[WIP] Check whether the Kite daemon is running when atom starts

### DIFF
--- a/atom/kite/lib/events.js
+++ b/atom/kite/lib/events.js
@@ -1,11 +1,13 @@
-var fs = require('fs');
-var http = require('http');
-var utils = require('./utils.js');
+const fs = require('fs');
+const http = require('http');
+const utils = require('./utils.js');
+const metrics = require('./metrics.js');
+const ready = require('./ready.js');
 
-var DEBUG = false;
+const DEBUG = false;
 
 // MAX_PAYLOAD_SIZE is the maximum length for a POST reqest body
-var MAX_PAYLOAD_SIZE = 2 << 20;
+const MAX_PAYLOAD_SIZE = 2 << 20;
 
 // Outgoing contains logic for sending events to Kite in response to
 // editor actions. We track edit, selections, and focus. These events
@@ -86,6 +88,10 @@ function httpRoundTrip(endpoint, obj) {
   };
 
   var req = http.request(options);
+  req.on('error', () => {
+    metrics.track("http connection failed", options);
+    ready.ensure();
+  });
   req.write(payload);
   req.end();
 }

--- a/atom/kite/lib/kite.js
+++ b/atom/kite/lib/kite.js
@@ -7,7 +7,6 @@ var ready = require('./ready.js');
 
 module.exports = {
   activate: function() {
-    console.log("at kite.activate");
     // observeTextEditors takes a callback that fires whenever a new
     // editor window is created. We use this to call "observeEditor",
     // which registers edit/selection based callbacks.
@@ -16,7 +15,6 @@ module.exports = {
     // focus is tracked at the workspace level.
     atom.workspace.onDidChangeActivePaneItem(events.onFocus);
 
-    console.log("calling ready.ensure...");
     ready.ensure();
   },
   completions: function() {

--- a/atom/kite/lib/kite.js
+++ b/atom/kite/lib/kite.js
@@ -3,9 +3,11 @@
 
 var events = require('./events.js')
 var completions = require('./completions.js');
+var ready = require('./ready.js');
 
 module.exports = {
   activate: function() {
+    console.log("at kite.activate");
     // observeTextEditors takes a callback that fires whenever a new
     // editor window is created. We use this to call "observeEditor",
     // which registers edit/selection based callbacks.
@@ -13,6 +15,9 @@ module.exports = {
 
     // focus is tracked at the workspace level.
     atom.workspace.onDidChangeActivePaneItem(events.onFocus);
+
+    console.log("calling ready.ensure...");
+    ready.ensure();
   },
   completions: function() {
     return completions;

--- a/atom/kite/lib/kite.js
+++ b/atom/kite/lib/kite.js
@@ -1,12 +1,15 @@
 // Contents of this plugin will be reset by Kite on start. Changes you make
 // are not guaranteed to persist.
 
-var events = require('./events.js')
-var completions = require('./completions.js');
-var ready = require('./ready.js');
+const metrics = require('./metrics.js');
+const events = require('./events.js');
+const completions = require('./completions.js');
+const ready = require('./ready.js');
 
 module.exports = {
   activate: function() {
+    metrics.track(metrics.events.ACTIVATE);
+
     // observeTextEditors takes a callback that fires whenever a new
     // editor window is created. We use this to call "observeEditor",
     // which registers edit/selection based callbacks.

--- a/atom/kite/lib/kite.js
+++ b/atom/kite/lib/kite.js
@@ -1,14 +1,13 @@
 // Contents of this plugin will be reset by Kite on start. Changes you make
 // are not guaranteed to persist.
-
-const metrics = require('./metrics.js');
 const events = require('./events.js');
 const completions = require('./completions.js');
 const ready = require('./ready.js');
+const metrics = require('./metrics.js');
 
 module.exports = {
   activate: function() {
-    metrics.track(metrics.events.ACTIVATE);
+    metrics.track("activated");
 
     // observeTextEditors takes a callback that fires whenever a new
     // editor window is created. We use this to call "observeEditor",

--- a/atom/kite/lib/localconfig.js
+++ b/atom/kite/lib/localconfig.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+
+const configPath = path.join(path.dirname(atom.config.getUserConfigPath()), "kite-config.json");
+
+var config = null;
+
+(function() {
+  try {
+    console.log("initializing localconfig from "+configPath+"...");
+    var str = fs.readFileSync(configPath, {encoding: 'utf8'});
+    config = JSON.parse(str);
+  } catch(err) {
+    config = {};
+  }
+})();
+
+function persist() {
+  var str = JSON.stringify(config, null, 2); // serialize with whitespace for human readability
+  fs.writeFile(configPath, str, 'utf8', (err) => {
+    if (err) {
+      console.log("failed to persist localconfig to "+configPath, err);
+    }
+  });
+}
+
+// get gets a value from storage
+function get(key, fallback) {
+  return (config[key] === undefined) ? fallback : config[key];
+}
+
+// set assigns a value to storage and asynchronously persists it to disk
+function set(key, value) {
+  config[key] = value;
+  persist();   // will write to disk asynchronously
+}
+
+module.exports = {
+  get: get,
+  set: set,
+};

--- a/atom/kite/lib/metrics.js
+++ b/atom/kite/lib/metrics.js
@@ -2,6 +2,7 @@ var os = require('os');
 const mixpanel = require('mixpanel');
 const crypto = require('crypto');
 const kitePkg = require('../package.json');
+const localconfig = require('./localconfig.js');
 
 const MIXPANEL_TOKEN = '2ab52cc896c9c74a7452d65f00e4f938';
 
@@ -18,10 +19,10 @@ var events = {
 
 // Generate a unique ID for this user and save it for future use.
 function distinctID() {
-  var id = atom.config.get('kite.distinctID');
+  var id = localconfig.get('distinctID');
   if (id === undefined) {
     id = crypto.randomBytes(32).toString('hex');
-    atom.config.set('kite.distinctID', id);
+    localconfig.set('distinctID', id);
   }
   return id;
 }

--- a/atom/kite/lib/metrics.js
+++ b/atom/kite/lib/metrics.js
@@ -1,8 +1,11 @@
+var os = require('os');
 const mixpanel = require('mixpanel');
 const crypto = require('crypto');
 const kitePkg = require('../package.json');
 
 const MIXPANEL_TOKEN = '2ab52cc896c9c74a7452d65f00e4f938';
+
+const OS_VERSION = os.type() + ' ' + os.release();
 
 const client = mixpanel.init(MIXPANEL_TOKEN, {
   protocol: 'https',
@@ -17,10 +20,9 @@ var events = {
 function distinctID() {
   var id = atom.config.get('kite.distinctID');
   if (id === undefined) {
-    id = btoa(crypto.randomBytes(64));
+    id = crypto.randomBytes(32).toString('hex');
     atom.config.set('kite.distinctID', id);
   }
-  console.log("id:", id);
   return id;
 }
 
@@ -35,6 +37,7 @@ function track(eventName, properties) {
       distinct_id: distinctID(),
       atom_version: atom.getVersion(),
       kite_plugin_version: kitePkg.version,
+      os: OS_VERSION,
   };
   if (properties !== undefined) {
     for (var key in properties) {
@@ -43,3 +46,7 @@ function track(eventName, properties) {
   }
   client.track(eventName, properties);
 }
+
+module.exports = {
+  track: track,
+};

--- a/atom/kite/lib/metrics.js
+++ b/atom/kite/lib/metrics.js
@@ -1,0 +1,45 @@
+const mixpanel = require('mixpanel');
+const crypto = require('crypto');
+const kitePkg = require('../package.json');
+
+const MIXPANEL_TOKEN = '2ab52cc896c9c74a7452d65f00e4f938';
+
+const client = mixpanel.init(MIXPANEL_TOKEN, {
+  protocol: 'https',
+});
+
+// The list of all possible events
+var events = {
+  ACTIVATE: "activate",
+};
+
+// Generate a unique ID for this user and save it for future use.
+function distinctID() {
+  var id = atom.config.get('kite.distinctID');
+  if (id === undefined) {
+    id = btoa(crypto.randomBytes(64));
+    atom.config.set('kite.distinctID', id);
+  }
+  console.log("id:", id);
+  return id;
+}
+
+// Send an event to mixpanel
+function track(eventName, properties) {
+  if (properties === undefined) {
+    console.log("event: " + eventName);
+  } else {
+    console.log("event: " + eventName, properties);
+  }
+  eventData = {
+      distinct_id: distinctID(),
+      atom_version: atom.getVersion(),
+      kite_plugin_version: kitePkg.version,
+  };
+  if (properties !== undefined) {
+    for (var key in properties) {
+      eventData[key] = properties[key];
+    }
+  }
+  client.track(eventName, properties);
+}

--- a/atom/kite/lib/ready.js
+++ b/atom/kite/lib/ready.js
@@ -17,9 +17,10 @@ var Ready = {
   // and enabled in the current directory. If any of these checks fail then an
   // appropriate noficiation is displayed with a button that lets the user fix
   // the problem.
-  ensure: function() {
+  ensure: function(notifyOnReady) {
     var curpath = this.currentPath();
     StateController.handleState(curpath).then((state) => {
+      console.log("state:", state);
       switch (state) {
         case StateController.STATES.UNSUPPORTED:
           this.warnNotSupported();
@@ -39,15 +40,25 @@ var Ready = {
         case StateController.STATES.AUTHENTICATED:
           if (curpath !== null) {
             this.warnNotWhitelisted(curpath);
+          } else if (notifyOnReady !== undefined) {
+            this.notifyReady();
           }
           break;
         case StateController.STATES.WHITELISTED:
           metrics.track("kite is ready");
+          if (notifyOnReady !== undefined) {
+            this.notifyReady();
+          }
           break;
       }
     }, (err) => {
       metrics.track("handleState failed", err);
     });
+  },
+
+  // ensureAndNotify is like ensure but also shows a success notification if Kite is already running.
+  ensureAndNotify: function() {
+    this.ensure(true);
   },
 
   warnNotSupported: function() {
@@ -114,13 +125,14 @@ var Ready = {
     metrics.track("not-running warning shown");
     var notification = atom.notifications.addWarning(
       "The Kite autocomplete daemon is not running", {
-      description: "In order to provide completions the Kite daemon needs to be running.",
+      description: "In order to provide completions the Kite daemon needs to be started.",
       icon: "circle-slash",
       dismissable: true,
       buttons: [{
         text: "Start Kite",
         onDidClick: () => {
           metrics.track("start button clicked (via not-running warning)");
+          notification.dismiss();
           this.launch();
         }
       }]
@@ -147,6 +159,7 @@ var Ready = {
           text: "Retry",
           onDidClick: () => {
             metrics.track("retry button clicked (via launch error)");
+            notification.dismiss();
             this.launch();
           }
         }]
@@ -179,6 +192,7 @@ var Ready = {
         text: "Login",
         onDidClick: () => {
           metrics.track("login button clicked (via not-authenticated warning)");
+          notification.dismiss();
           this.authenticate();
         }
       }]
@@ -207,6 +221,7 @@ var Ready = {
           text: "Retry",
           onDidClick: () => {
             metrics.track("retry button clicked (via authentication error)");
+            notification.dismiss();
             this.authenticate();
           }
         }]
@@ -230,6 +245,7 @@ var Ready = {
         text: "Enable Kite for "+dir,
         onDidClick: () => {
           metrics.track("enable button clicked (via not-whitelisted warning)", {dir: dir});
+          notification.dismiss();
           this.whitelist(dir);
         }
       }]
@@ -253,6 +269,7 @@ var Ready = {
           text: "Retry",
           onDidClick: () => {
             metrics.track("retry clicked (via whitelisting-failed error)", {dir: dirpath});
+            notification.dismiss();
             this.whitelist(dirpath);
           }
         }]
@@ -262,6 +279,17 @@ var Ready = {
       });
     });
   },
+
+  notifyReady: function() {
+    metrics.track("ready notification shown");
+    atom.notifications.addSuccess(
+      "The Kite autocomplete daemon is ready", {
+      description: "We checked that the daemon is installed, running, responsive, and authenticated.",
+      dismissable: true,
+    }).onDidDismiss(() => {
+      metrics.track("ready notification dismissed");
+    });
+  }
 };
 
 module.exports = Ready;

--- a/atom/kite/lib/ready.js
+++ b/atom/kite/lib/ready.js
@@ -1,6 +1,7 @@
 const os = require('os');
 const path = require('path');
 const utils = require('./utils.js');
+const metrics = require('./metrics.js');
 const StateController = require('kite-installer/lib/state-controller.js');
 
 var Ready = {
@@ -19,51 +20,48 @@ var Ready = {
   ensure: function() {
     var curpath = this.currentPath();
     StateController.handleState(curpath).then((state) => {
-      console.log("current state is "+state);
       switch (state) {
         case StateController.STATES.UNSUPPORTED:
-          console.log("kite is not supported");
           this.warnNotSupported();
           break;
         case StateController.STATES.UNINSTALLED:
-          console.log("kite is not installed");
           this.warnNotInstalled();
           break;
         case StateController.STATES.INSTALLED:
-          console.log("kite is installed but not running");
           this.warnNotRunning();
           break;
         case StateController.STATES.RUNNING:
-          console.log("kite is running but not reachable");
           this.warnNotReachable();
           break;
         case StateController.STATES.REACHABLE:
-          console.log("kite is reachable but not authenticated");
           this.warnNotAuthenticated();
           break;
         case StateController.STATES.AUTHENTICATED:
-          console.log("kite is reachable but dir is not whitelisted");
           this.warnNotWhitelisted(curpath);
           break;
         case StateController.STATES.WHITELISTED:
-          console.log("kite is ready");
+          metrics.track("kite is ready");
           break;
       }
     }, (err) => {
-      console.log("handleState failed: ", err);
+      metrics.track("handleState failed", err);
     });
   },
 
   warnNotSupported: function() {
+    metrics.track("not-supported warning shown");
     atom.notifications.addError(
       "The Kite autocomplete daemon is not supported on this platform", {
       description: "Kite is currently only supported on macOS.",
       icon: "circle-slash",
       dismissable: true,
+    }).onDidDismiss(() => {
+      metrics.track("not-supported warning dismissed");
     });
   },
 
   warnNotInstalled: function() {
+    metrics.track("not-installed warning shown");
     var notification = atom.notifications.addWarning(
       "The Kite autocomplete daemon is not installed", {
       description: "In order to provide completions the Kite daemon needs to be installed.",
@@ -72,39 +70,46 @@ var Ready = {
       buttons: [{
         text: "Install Kite",
         onDidClick: () => {
+          metrics.track("install button clicked (via not-installed warning)");
           notification.dismiss();
           this.install();
         }
       }]
     });
-    notification.onDidDismiss(this.onDismiss);
+    notification.onDidDismiss(() => {
+      metrics.track("not-installed warning dismissed");
+    });
   },
 
   install: function() {
-    console.log("installing kite...");
+    metrics.track("download-and-install started");
     StateController.installKiteRelease().then(() => {
-      console.log("kite is installed, now attempting to start...");
+      metrics.track("download-and-install succeeded");
       this.launch();
     }, (err) => {
       // installation failed, show an error notification
-      console.log("installation failed: ", err);
+      metrics.track("download-and-install failed");
       var notification = atom.notifications.addError("Unable to install Kite", {
         description: JSON.stringify(err),
         dismissable: true,
         buttons: [{
           text: "Retry",
           onDidClick: () => {
+            metrics.track("retry button clicked (via download-and-install error)");
             notification.dismiss();
             this.install();
           }
         }]
       });
-      notification.onDidDismiss(this.onDismiss);
+      notification.onDidDismiss(() => {
+        metrics.track("download-and-install error dismissed");
+      });
     });
     // TODO: on failure display a notification with an option to retry
   },
 
   warnNotRunning: function() {
+    metrics.track("not-running warning shown");
     var notification = atom.notifications.addWarning(
       "The Kite autocomplete daemon is not running", {
       description: "In order to provide completions the Kite daemon needs to be running.",
@@ -113,47 +118,58 @@ var Ready = {
       buttons: [{
         text: "Start Kite",
         onDidClick: () => {
+          metrics.track("start button clicked (via not-running warning)");
           notification.dismiss();
           this.launch();
         }
       }]
     });
-    notification.onDidDismiss(this.onDismiss);
+    notification.onDidDismiss(() => {
+      metrics.track("not-running warning dismissed");
+    });
   },
 
   launch: function() {
-    console.log("starting kite...");
+    metrics.track("launch started");
     StateController.runKite().then(() => {
       // TODO: remove this "sleep" after the runKite promise resolves only when kite is running
       setTimeout(() => {
-        console.log("Kite started successfully, going back to ensure...");
+        metrics.track("launch succeeded");
         this.ensure();
       }, 5000);
     }, (err) => {
+      metrics.track("launch failed");
       var notification = atom.notifications.addError("Unable to start Kite autocomplete daemon", {
         description: JSON.stringify(err),
         dismissable: true,
         buttons: [{
           text: "Retry",
           onDidClick: () => {
+            metrics.track("retry button clicked (via launch error)");
             notification.dismiss();
             this.launch();
           }
         }]
       });
-      notification.onDidDismiss(this.onDismiss);
+      notification.onDidDismiss(() => {
+        metrics.track("launch error dismissed");
+      });
     });
   },
 
   warnNotReachable: function() {
+    metrics.track("not-reachable warning shown");
     atom.notifications.addError(
       "The Kite autocomplete daemon is running but not reachable", {
       description: "Try killing Kite from Activity Monitor.",
       dismissable: true,
-    }).onDidDismiss(this.onDismiss);
+    }).onDidDismiss(() => {
+      metrics.track("not-reachable warning dismissed");
+    });
   },
 
   warnNotAuthenticated: function() {
+    metrics.track("not-authenticated warning shown");
     var notification = atom.notifications.addWarning(
       "You need to log in to the Kite autocomplete daemon", {
       description: "In order to provide completions the Kite daemon needs to be authenticated (so that it can access the index of your code stored on the cloud).",
@@ -162,42 +178,50 @@ var Ready = {
       buttons: [{
         text: "Login",
         onDidClick: () => {
+          metrics.track("login button clicked (via not-authenticated warning)");
           notification.dismiss();
           this.authenticate();
         }
       }]
     });
-    notification.onDidDismiss(this.onDismiss);
+    notification.onDidDismiss(() => {
+      metrics.track("not-authenticated warning dismissed");
+    });
   },
 
   authenticate: function() {
-    console.log("user chose to log in to kite...");
+    metrics.track("authentication started");
 
     // TODO: show some kind of login UI
     var email = "test@kite.com";
     var password = "123123";
 
     StateController.authenticateUser(email, password).then(() => {
-      console.log("authentication succeeded, going back to ensure...");
+      metrics.track("authentication succeeded");
       this.ensure();
     }, (err) => {
-      console.log("authentication failed:", err);
+      metrics.track("authentication failed");
       var notification = atom.notifications.addError("Unable to login", {
         description: JSON.stringify(err),
         dismissable: true,
         buttons: [{
           text: "Retry",
           onDidClick: () => {
+            metrics.track("retry button clicked (via authentication error)");
             notification.dismiss();
             this.authenticate();
           }
-        }]
+        }]).onDidDismiss(() => {
+          metrics.track("authentication error dismissed");
+        });
       });
     });
   },
 
   warnNotWhitelisted: function(filepath) {
     var dir = path.dirname(filepath);
+    metrics.track("not-whitelisted warning shown", {dir: dir});
+
     var notification = atom.notifications.addWarning(
       "Kite completions are not enabled for "+filepath, {
       description: "Kite only processes files in enabled directories. If you enable Kite then files in this directory will be synced to the Kite backend, where they will be analyzed and indexed.",
@@ -206,38 +230,40 @@ var Ready = {
       buttons: [{
         text: "Enable Kite for "+dir,
         onDidClick: () => {
+          metrics.track("enable button clicked (via not-whitelisted warning)", {dir: dir});
           notification.dismiss();
           this.whitelist(dir);
         }
       }]
     });
-    notification.onDidDismiss(this.onDismiss);
+    notification.onDidDismiss(() => {
+      metrics.track("not-whitelisted warning dismissed", {dir: dir});
+    });
   },
 
   whitelist: function(dirpath) {
-    console.log("user chose to whitelist " + dirpath);
+    metrics.track("whitelisting started", {dir: dirpath});
     StateController.whitelistPath(dirpath).then(() => {
-      console.log("successfully whitelisted, going back to ensure...");
+      metrics.track("whitelisting succeeded", {dir: dirpath});
       this.ensure();
     }, (err) => {
-      console.log("whitelist failed:", err);
+      metrics.track("whitelisting failed", {dir: dirpath});
       var notification = atom.notifications.addError("Unable to enable Kite for "+dirpath, {
         description: JSON.stringify(err),
         dismissable: true,
         buttons: [{
           text: "Retry",
           onDidClick: () => {
+            metrics.track("retry clicked (via whitelisting-failed error)", {dir: dirpath});
             notification.dismiss();
             this.whitelist(dirpath);
           }
         }]
+      }).onDidDismiss(() => {
+        metrics.track("whitelisting error dismissed");
       });
     });
   },
-
-  onDismiss: function() {
-    console.log("notification was dismissed");
-  }
 };
 
 module.exports = Ready;

--- a/atom/kite/lib/ready.js
+++ b/atom/kite/lib/ready.js
@@ -1,0 +1,243 @@
+const os = require('os');
+const path = require('path');
+const utils = require('./utils.js');
+const StateController = require('kite-installer/lib/state-controller.js');
+
+var Ready = {
+  currentPath: function() {
+    var editor = atom.workspace.getActivePaneItem();
+    if (editor === undefined) {
+      return null;
+    }
+    return editor.buffer.file.path;
+  },
+
+  // ensure checks that Kite is installed, running, reachable, authenticated,
+  // and enabled in the current directory. If any of these checks fail then an
+  // appropriate noficiation is displayed with a button that lets the user fix
+  // the problem.
+  ensure: function() {
+    var curpath = this.currentPath();
+    StateController.handleState(curpath).then((state) => {
+      console.log("current state is "+state);
+      switch (state) {
+        case StateController.STATES.UNSUPPORTED:
+          console.log("kite is not supported");
+          this.warnNotSupported();
+          break;
+        case StateController.STATES.UNINSTALLED:
+          console.log("kite is not installed");
+          this.warnNotInstalled();
+          break;
+        case StateController.STATES.INSTALLED:
+          console.log("kite is installed but not running");
+          this.warnNotRunning();
+          break;
+        case StateController.STATES.RUNNING:
+          console.log("kite is running but not reachable");
+          this.warnNotReachable();
+          break;
+        case StateController.STATES.REACHABLE:
+          console.log("kite is reachable but not authenticated");
+          this.warnNotAuthenticated();
+          break;
+        case StateController.STATES.AUTHENTICATED:
+          console.log("kite is reachable but dir is not whitelisted");
+          this.warnNotWhitelisted(curpath);
+          break;
+        case StateController.STATES.WHITELISTED:
+          console.log("kite is ready");
+          break;
+      }
+    }, (err) => {
+      console.log("handleState failed: ", err);
+    });
+  },
+
+  warnNotSupported: function() {
+    atom.notifications.addError(
+      "The Kite autocomplete daemon is not supported on this platform", {
+      description: "Kite is currently only supported on macOS.",
+      icon: "circle-slash",
+      dismissable: true,
+    });
+  },
+
+  warnNotInstalled: function() {
+    var notification = atom.notifications.addWarning(
+      "The Kite autocomplete daemon is not installed", {
+      description: "In order to provide completions the Kite daemon needs to be installed.",
+      icon: "circle-slash",
+      dismissable: true,
+      buttons: [{
+        text: "Install Kite",
+        onDidClick: () => {
+          notification.dismiss();
+          this.install();
+        }
+      }]
+    });
+    notification.onDidDismiss(this.onDismiss);
+  },
+
+  install: function() {
+    console.log("installing kite...");
+    StateController.installKiteRelease().then(() => {
+      console.log("kite is installed, now attempting to start...");
+      this.launch();
+    }, (err) => {
+      // installation failed, show an error notification
+      console.log("installation failed: ", err);
+      var notification = atom.notifications.addError("Unable to install Kite", {
+        description: JSON.stringify(err),
+        dismissable: true,
+        buttons: [{
+          text: "Retry",
+          onDidClick: () => {
+            notification.dismiss();
+            this.install();
+          }
+        }]
+      });
+      notification.onDidDismiss(this.onDismiss);
+    });
+    // TODO: on failure display a notification with an option to retry
+  },
+
+  warnNotRunning: function() {
+    var notification = atom.notifications.addWarning(
+      "The Kite autocomplete daemon is not running", {
+      description: "In order to provide completions the Kite daemon needs to be running.",
+      icon: "circle-slash",
+      dismissable: true,
+      buttons: [{
+        text: "Start Kite",
+        onDidClick: () => {
+          notification.dismiss();
+          this.launch();
+        }
+      }]
+    });
+    notification.onDidDismiss(this.onDismiss);
+  },
+
+  launch: function() {
+    console.log("starting kite...");
+    StateController.runKite().then(() => {
+      // TODO: remove this "sleep" after the runKite promise resolves only when kite is running
+      setTimeout(() => {
+        console.log("Kite started successfully, going back to ensure...");
+        this.ensure();
+      }, 5000);
+    }, (err) => {
+      var notification = atom.notifications.addError("Unable to start Kite autocomplete daemon", {
+        description: JSON.stringify(err),
+        dismissable: true,
+        buttons: [{
+          text: "Retry",
+          onDidClick: () => {
+            notification.dismiss();
+            this.launch();
+          }
+        }]
+      });
+      notification.onDidDismiss(this.onDismiss);
+    });
+  },
+
+  warnNotReachable: function() {
+    atom.notifications.addError(
+      "The Kite autocomplete daemon is running but not reachable", {
+      description: "Try killing Kite from Activity Monitor.",
+      dismissable: true,
+    }).onDidDismiss(this.onDismiss);
+  },
+
+  warnNotAuthenticated: function() {
+    var notification = atom.notifications.addWarning(
+      "You need to log in to the Kite autocomplete daemon", {
+      description: "In order to provide completions the Kite daemon needs to be authenticated (so that it can access the index of your code stored on the cloud).",
+      icon: "circle-slash",
+      dismissable: true,
+      buttons: [{
+        text: "Login",
+        onDidClick: () => {
+          notification.dismiss();
+          this.authenticate();
+        }
+      }]
+    });
+    notification.onDidDismiss(this.onDismiss);
+  },
+
+  authenticate: function() {
+    console.log("user chose to log in to kite...");
+
+    // TODO: show some kind of login UI
+    var email = "test@kite.com";
+    var password = "123123";
+
+    StateController.authenticateUser(email, password).then(() => {
+      console.log("authentication succeeded, going back to ensure...");
+      this.ensure();
+    }, (err) => {
+      console.log("authentication failed:", err);
+      var notification = atom.notifications.addError("Unable to login", {
+        description: JSON.stringify(err),
+        dismissable: true,
+        buttons: [{
+          text: "Retry",
+          onDidClick: () => {
+            notification.dismiss();
+            this.authenticate();
+          }
+        }]
+      });
+    });
+  },
+
+  warnNotWhitelisted: function(filepath) {
+    var dir = path.dirname(filepath);
+    var notification = atom.notifications.addWarning(
+      "Kite completions are not enabled for "+filepath, {
+      description: "Kite only processes files in enabled directories. If you enable Kite then files in this directory will be synced to the Kite backend, where they will be analyzed and indexed.",
+      icon: "circle-slash",
+      dismissable: true,
+      buttons: [{
+        text: "Enable Kite for "+dir,
+        onDidClick: () => {
+          notification.dismiss();
+          this.whitelist(dir);
+        }
+      }]
+    });
+    notification.onDidDismiss(this.onDismiss);
+  },
+
+  whitelist: function(dirpath) {
+    console.log("user chose to whitelist " + dirpath);
+    StateController.whitelistPath(dirpath).then(() => {
+      console.log("successfully whitelisted, going back to ensure...");
+      this.ensure();
+    }, (err) => {
+      console.log("whitelist failed:", err);
+      var notification = atom.notifications.addError("Unable to enable Kite for "+dirpath, {
+        description: JSON.stringify(err),
+        dismissable: true,
+        buttons: [{
+          text: "Retry",
+          onDidClick: () => {
+            notification.dismiss();
+            this.whitelist(dirpath);
+          }
+        }]
+      });
+    });
+  },
+
+  onDismiss: function() {
+    console.log("notification was dismissed");
+  }
+};
+
+module.exports = Ready;

--- a/atom/kite/package.json
+++ b/atom/kite/package.json
@@ -9,7 +9,8 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "kite-installer": "kite-installer"
+    "kite-installer": "kite-installer",
+    "mixpanel": "^0.5.0"
   },
   "providedServices": {
     "autocomplete.provider": {

--- a/atom/kite/package.json
+++ b/atom/kite/package.json
@@ -9,7 +9,6 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "dialogs": "^1.1.16",
     "kite-installer": "kite-installer"
   },
   "providedServices": {

--- a/atom/kite/package.json
+++ b/atom/kite/package.json
@@ -8,7 +8,10 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "dialogs": "^1.1.16",
+    "kite-installer": "kite-installer"
+  },
   "providedServices": {
     "autocomplete.provider": {
       "versions": {


### PR DESCRIPTION
This pr adds a function to check that Kite is installed, running, reachable, authenticated, and enabled in the current directory. If any of these checks fail then an appropriate noficiation is displayed with a button that lets the user fix the problem. It relies on the `kite-installer` package to perform the low-level checks, and to the installation / etc.

This is still quite a way from done. I am putting this up mostly to show where it's headed.